### PR TITLE
Remove unused Any import from utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ Utility functions for the Wittgenstein chatbot.
 
 import os
 import json
-from typing import List, Dict, Any
+from typing import List, Dict
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_openai import OpenAIEmbeddings
 from langchain.schema import Document


### PR DESCRIPTION
## Summary
- tidy utils by removing the unused `Any` import

## Testing
- `pre-commit` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866b6ff59bc8329918306f95ff09d26