### PR TITLE
Update README for setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ A terminal-based chatbot that role-plays as Ludwig Wittgenstein using Retrieval-
 
 ## Setup and Data Ingestion
 
+You can run `python setup.py` to automatically create sample data and build all
+indexes. This script performs both sample data creation and
+`ingest_all()` in one step. The manual commands below provide an alternative if
+you prefer to run them separately.
+
 1. **Create sample data** (for testing):
    ```bash
    python -c "from loaders.ingest import DataIngester; DataIngester().create_sample_data()"


### PR DESCRIPTION
## Summary
- add note on running `python setup.py` for automated setup
- keep manual commands as an alternative

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866b9051630832988b4bc8a0bc0e6bd