### PR TITLE
Add customizable prompt template

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,12 @@ export LANGSMITH_PROJECT='wittgenstein-chatbot'
 
 ### Modifying Wittgenstein's Style
 
-Edit the system prompt in `prompt_builder.py` to adjust:
+Edit the system prompt in `prompt_template.md` to adjust:
 - Philosophical approach
 - Writing style
 - Response characteristics
+
+Response length is guided by the **Response Length** section of `prompt_template.md` and by `Config.MAX_TOKENS` in `config.py`.
 
 ### Adjusting Retrieval
 

--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -4,11 +4,14 @@ Constructs dynamic prompts using retrieved content from all knowledge bases.
 """
 
 from typing import List, Dict, Any
+import os
 from retrievers.authored import AuthoredTextRetriever
 from retrievers.descriptive import DescriptiveSourceRetriever
 from retrievers.external import ExternalKnowledgeRetriever
 from utils import truncate_text
 from config import Config
+
+TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "prompt_template.md")
 
 
 class PromptBuilder:
@@ -63,7 +66,11 @@ class PromptBuilder:
         Returns:
             System prompt string
         """
-        return """You are Ludwig Wittgenstein, the Austrian-British philosopher. You are engaging in a philosophical conversation with someone who seeks your insights.
+        try:
+            with open(TEMPLATE_PATH, "r", encoding="utf-8") as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            return """You are Ludwig Wittgenstein, the Austrian-British philosopher. You are engaging in a philosophical conversation with someone who seeks your insights.
 
 IMPORTANT INSTRUCTIONS:
 1. Respond as Wittgenstein would, using his distinctive philosophical style and approach

--- a/prompt_template.md
+++ b/prompt_template.md
@@ -1,0 +1,11 @@
+# System Role
+You are Ludwig Wittgenstein, the Austrian-British philosopher. Engage the user in philosophical dialogue reflecting Wittgenstein's distinctive style and method.
+
+# Context Integration
+Use the passages retrieved from your writings, descriptive commentary, and external knowledge as inspiration. Integrate this material into your answers rather than quoting it directly.
+
+# Response Length
+Aim to stay well under `Config.MAX_TOKENS` tokens when replying. This typically means no more than two or three short paragraphs.
+
+# Style/Tone Adjustments
+This section may be edited to tweak Wittgenstein's tone or approach. For example, you might instruct more Socratic questioning, a casual tone, or a purely analytical style.


### PR DESCRIPTION
## Summary
- allow editing Wittgenstein's system prompt in `prompt_template.md`
- load system prompt from markdown file in `prompt_builder.py`
- document how to adjust style and response length via the template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866ceee6f108329850323e1aacb6269