### PR TITLE
Improve README and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,104 +1,113 @@
 # Wittgenstein Chatbot
 
-A terminal-based chatbot that role-plays as Ludwig Wittgenstein using Retrieval-Augmented Generation (RAG). The chatbot combines Wittgenstein's own writings, philosophical commentary, and external knowledge to provide contextually relevant responses in his distinctive style.
+A terminal-based chatbot that role-plays as Ludwig Wittgenstein using Retrieval-Augmented Generation (RAG). The chatbot combines Wittgenstein's writings, philosophical commentary, and modern knowledge to provide contextually relevant responses in his style.
+
+## Table of Contents
+- [Quick Start](#quick-start)
+- [Example Conversation](#example-conversation)
+- [Features](#features)
+- [Project Structure](#project-structure)
+- [Installation](#installation)
+- [Setup and Data Ingestion](#setup-and-data-ingestion)
+- [Data Sources](#data-sources)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [How It Works](#how-it-works)
+- [Customization](#customization)
+- [Requirements](#requirements)
+- [Dependencies](#dependencies)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Quick Start
-
 ```bash
 pip install -r requirements.txt
 python setup.py  # builds FAISS indexes from included data
 python main.py
 ```
 
-## Features
+## Example Conversation
+```
+User: How would you describe the "private language" argument?
+Bot: In ordinary language, the idea of a purely private language is incoherent. To understand a word is to master its public use, not to consult an inner diary. Thus, any "private" language would lack the criteria for correctness we rely on in everyday speech.
+```
 
-- **Three-tier RAG System**: Uses separate FAISS indexes for different types of knowledge:
-  - `authored_text`: Wittgenstein's own writings (for style and approach)
-  - `descriptive_sources`: Commentary about his thought (for philosophical context)
-  - `external_knowledge`: Facts outside his time (for modern context)
-- **Dynamic Prompt Construction**: Builds contextually relevant prompts using retrieved content
-- **OpenAI Integration**: Uses GPT-4 or GPT-3.5-turbo for generating responses
-- **Conversation Memory**: Maintains conversation history for contextual responses
-- **Terminal Interface**: Clean, interactive command-line interface
+## Features
+- **Three-tier RAG System**: Separate FAISS indexes for different knowledge types:
+  - `authored_text`: Wittgenstein's own writings
+  - `descriptive_sources`: Philosophical commentary
+  - `external_knowledge`: Modern facts and concepts
+- **Dynamic Prompt Construction** for contextually relevant prompts
+- **OpenAI Integration** with GPT-4 or GPT-3.5-turbo
+- **Conversation Memory** to maintain context
+- **Terminal Interface** for interactive use
 
 ## Project Structure
-
 ```
 ├── main.py                 # Main application entry point
-├── config.py              # Configuration settings
-├── prompt_builder.py      # Dynamic prompt construction
-├── retrievers/           # Knowledge retrieval modules
+├── config.py               # Configuration settings
+├── prompt_builder.py       # Dynamic prompt construction
+├── retrievers/             # Knowledge retrieval modules
 │   ├── __init__.py
-│   ├── authored.py       # Wittgenstein's writings retriever
-│   ├── descriptive.py    # Commentary retriever
-│   └── external.py       # External knowledge retriever
-├── loaders/              # Data ingestion modules
+│   ├── authored.py         # Wittgenstein's writings retriever
+│   ├── descriptive.py      # Commentary retriever
+│   └── external.py         # External knowledge retriever
+├── loaders/                # Data ingestion modules
 │   ├── __init__.py
-│   └── ingest.py         # Data processing and indexing
-├── data/                 # Text data directories
-│   ├── authored_texts/   # Wittgenstein's writings
-│   ├── descriptive_sources/ # Commentary and analysis
-│   └── external_knowledge/  # Modern facts and concepts
-├── indexes/              # FAISS vector indexes
+│   └── ingest.py           # Data processing and indexing
+├── data/                   # Text data directories
+│   ├── authored_texts/     # Wittgenstein's writings
+│   ├── descriptive_sources/# Commentary and analysis
+│   └── external_knowledge/ # Modern facts and concepts
+├── indexes/                # FAISS vector indexes
 │   ├── faiss_authored/
 │   ├── faiss_descriptive/
 │   └── faiss_external/
-└── utils.py              # Utility functions
+└── utils.py                # Utility functions
 ```
 
 ## Installation
-
-1. **Clone the repository**:
+1. **Clone the repository**
    ```bash
-   git clone https://github.com/syncletica/wittgenstein-chat-v2.git
-   cd wittgenstein-chat-v2
-   ```
-
-2. **Install dependencies**:
+git clone https://github.com/syncletica/wittgenstein-chat-v2.git
+cd wittgenstein-chat-v2
+```
+2. **Install dependencies**
    ```bash
-   pip install -r requirements.txt
-   ```
-
-3. **Set up OpenAI API key**:
+pip install -r requirements.txt
+```
+3. **Set up environment variables**
    ```bash
-   export OPENAI_API_KEY='your-api-key-here'
-   ```
-   Or create a `.env` file:
-   ```
-   OPENAI_API_KEY=your-api-key-here
-   ```
+export OPENAI_API_KEY='your-api-key-here'
+# Optional: enable LangSmith tracing
+export LANGSMITH_API_KEY='your-langsmith-key'
+export LANGSMITH_PROJECT='wittgenstein-chatbot'
+```
+   You can also create a `.env` file with the same variables.
 
 ## Setup and Data Ingestion
-
-This repository comes pre-loaded with a comprehensive collection of Wittgenstein's writings, philosophical commentary, and modern knowledge sources. You can start using the chatbot immediately by running the setup script.
+This repository includes sample data so you can start chatting immediately.
 
 ### Quick Setup (Recommended)
-
-Run `python setup.py` to automatically build all FAISS indexes from the included data:
-
+Run `python setup.py` to build FAISS indexes:
 ```bash
 python setup.py
 ```
 
 ### Manual Setup (Alternative)
-
-If you prefer to run the indexing process manually:
-
 ```bash
 python -c "from loaders.ingest import DataIngester; DataIngester().ingest_all()"
 ```
 
-
-
 ## Data Sources
-
-**authored_texts/** - Wittgenstein's Writings:
+**authored_texts/** – Wittgenstein's writings
 - [Tractatus Logico-Philosophicus](https://www.wittgensteinproject.org/w/index.php/Tractatus_Logico-Philosophicus_(English))
 - [Blue Book](https://www.wittgensteinproject.org/w/index.php/Blue_Book)
 - [Brown Book](https://www.wittgensteinproject.org/w/index.php/Brown_Book)
 - [Lecture on Ethics](https://www.wittgensteinproject.org/w/index.php/Lecture_on_Ethics)
 
-**descriptive_sources/** - Stanford Encyclopedia of Philosophy:
+**descriptive_sources/** – Stanford Encyclopedia of Philosophy
 - [Ludwig Wittgenstein](https://plato.stanford.edu/entries/wittgenstein/)
 - [Private Language](https://plato.stanford.edu/entries/private-language/)
 - [Rule Following](https://plato.stanford.edu/entries/rule-following/)
@@ -106,124 +115,77 @@ python -c "from loaders.ingest import DataIngester; DataIngester().ingest_all()"
 - [Wittgenstein's Atomism](https://plato.stanford.edu/entries/wittgenstein-atomism/)
 - [Wittgenstein's Philosophy of Mathematics](https://plato.stanford.edu/entries/wittgenstein-mathematics/)
 
-**external_knowledge/** - arXiv Papers:
+**external_knowledge/** – arXiv papers
 - [Understanding LLMs: A Comprehensive Overview from Training to Inference](https://arxiv.org/abs/2307.06435)
-- [Philosophical Introduction to Large Language Models](https://arxiv.org/abs/2307.06435)
-- [Comprehensive Overview of Large Language Models](https://arxiv.org/abs/2307.06435)
 
 ### Adding Your Own Data (Optional)
-
-You can enhance the chatbot by adding additional sources:
-
-1. **Add Wittgenstein's writings** to `data/authored_texts/`
-2. **Add philosophical commentary** to `data/descriptive_sources/`
-3. **Add modern knowledge** to `data/external_knowledge/`
-4. **Re-run the ingestion process**:
+1. Add texts to the relevant `data/` subdirectories
+2. Re-run the ingestion process:
    ```bash
    python -c "from loaders.ingest import DataIngester; DataIngester().ingest_all()"
    ```
 
-**Note**: The FAISS indexes are automatically regenerated when you run the ingestion process, so your new data will be included in future conversations.
-
 ## Usage
-
 ### Starting the Chatbot
-
 ```bash
 python main.py
 ```
 
 ### Available Commands
-
-- `help` - Show help information
-- `clear` - Clear conversation history
-- `status` - Show retriever status
-- `quit`, `exit`, `bye` - Exit the chatbot
+- `help` – Show help information
+- `clear` – Clear conversation history
+- `status` – Show retriever status
+- `quit`, `exit`, `bye` – Exit the chatbot
 
 ## Configuration
-
-Edit `config.py` to customize:
-
-- **OpenAI Settings**: Model choice, temperature, max tokens
-- **Retrieval Settings**: Number of results from each knowledge base
-- **Embedding Settings**: Chunk size, overlap, embedding model
-- **Chat Settings**: Conversation history length
-
-### LangSmith Tracing (optional)
-
-Set `LANGSMITH_API_KEY` and `LANGSMITH_PROJECT` to enable LangSmith tracing.
-This provides observability through the LangSmith dashboard and is not required
-for normal operation.
-
-```bash
-export LANGSMITH_API_KEY='your-langsmith-key'
-export LANGSMITH_PROJECT='wittgenstein-chatbot'
-```
+Edit `config.py` to adjust settings:
+- **OpenAI Settings** – model, temperature, max tokens
+- **Retrieval Settings** – number of results from each knowledge base
+- **Embedding Settings** – chunk size, overlap, embedding model
+- **Chat Settings** – conversation history length
+- **LangSmith Tracing** – controlled by `LANGSMITH_API_KEY` and `LANGSMITH_PROJECT`
 
 ## How It Works
-
-1. **Query Processing**: When you ask a question, the system searches all three knowledge bases
-2. **Content Retrieval**: Relevant passages are retrieved from:
-   - Wittgenstein's writings (for style and approach)
-   - Philosophical commentary (for context)
-   - External knowledge (for modern facts)
-3. **Prompt Construction**: A dynamic prompt is built combining:
-   - System instructions for Wittgenstein's role
-   - Retrieved content from all sources
-   - Conversation history
-   - Your current question
-4. **Response Generation**: OpenAI generates a response in Wittgenstein's style
-5. **Context Integration**: The response incorporates retrieved knowledge without direct quotation
+1. **Query Processing** – your question is processed and searches all knowledge bases
+2. **Content Retrieval** – relevant passages are retrieved
+3. **Prompt Construction** – builds a prompt with instructions, retrieved text, and history
+4. **Response Generation** – OpenAI produces a reply in Wittgenstein's style
+5. **Context Integration** – the reply incorporates retrieved knowledge
 
 ## Customization
-
-### Adding New Data Sources
-
-1. Add text files to the appropriate `data/` subdirectory
-2. Re-run the ingestion process
-3. The system will automatically include the new content
-
-### Modifying Wittgenstein's Style
-
-Edit the system prompt in `prompt_template.md` to adjust:
-- Philosophical approach
-- Writing style
-- Response characteristics
-
-Response length is guided by the **Response Length** section of `prompt_template.md` and by `Config.MAX_TOKENS` in `config.py`.
-
-### Adjusting Retrieval
-
-Modify the `TOP_K_*` settings in `config.py` to control how much content is retrieved from each knowledge base.
+- Add new data sources under `data/` and rerun ingestion
+- Edit `prompt_template.md` to adjust Wittgenstein's style
+- Tune retrieval settings via `TOP_K_*` in `config.py`
 
 ## Requirements
-
 - Python 3.8+
 - OpenAI API key
 - Internet connection for API calls
 
 ## Dependencies
-
-- `langchain` - RAG framework
-- `langchain-openai` - OpenAI integration
-- `faiss-cpu` - Vector similarity search
-- `openai` - OpenAI API client
-- `python-dotenv` - Environment variable management
-- `tiktoken` - Token counting
-- `numpy` - Numerical operations
+- `langchain`
+- `langchain-openai`
+- `faiss-cpu`
+- `openai`
+- `python-dotenv`
+- `tiktoken`
+- `numpy`
 
 ## Troubleshooting
-
 ### Common Issues
-
-1. **"No retrievers available"**: Run the data ingestion process first
-2. **"OpenAI API key required"**: Set your API key as an environment variable
-3. **Slow responses**: Consider using GPT-3.5-turbo instead of GPT-4
-4. **Memory issues**: Reduce chunk size or number of retrieved results
+1. **"No retrievers available"** – run the data ingestion process first
+2. **"OpenAI API key required"** – ensure your API key is set
+3. **Slow responses** – try GPT-3.5-turbo
+4. **Memory issues** – reduce chunk size or retrieval counts
 
 ### Performance Tips
-
 - Use GPT-3.5-turbo for faster responses
 - Reduce `TOP_K_*` values for quicker retrieval
 - Limit conversation history length
 - Use smaller chunk sizes for large documents
+
+## Contributing
+Contributions are welcome! Feel free to open issues or submit pull requests to improve the project.
+
+## License
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add MIT License
- restructure README with table of contents
- add example conversation
- clarify optional environment variables
- remove duplicate arXiv entries and document contributing and license sections

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866dfaf0ae48329be0dd917dada84f8