### PR TITLE
Clean up path modifications

### DIFF
--- a/loaders/ingest.py
+++ b/loaders/ingest.py
@@ -4,12 +4,7 @@ Handles loading, processing, and indexing of text data.
 """
 
 import os
-import json
 from typing import List, Dict, Any
-import sys
-
-# Add parent directory to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import load_text_files, split_texts, create_faiss_index
 from config import Config

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ A terminal-based chatbot that role-plays as Ludwig Wittgenstein using RAG.
 """
 
 import os
-import sys
 from typing import List, Dict
 from langchain_openai import ChatOpenAI
 from prompt_builder import PromptBuilder

--- a/retrievers/authored.py
+++ b/retrievers/authored.py
@@ -4,11 +4,7 @@ Used to determine response style and philosophical approach.
 """
 
 from typing import List, Tuple, Dict, Any
-import sys
 import os
-
-# Add parent directory to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import load_faiss_index, search_faiss_index
 from config import Config

--- a/retrievers/descriptive.py
+++ b/retrievers/descriptive.py
@@ -4,11 +4,7 @@ Used to provide philosophical context and interpretation.
 """
 
 from typing import List, Tuple, Dict, Any
-import sys
 import os
-
-# Add parent directory to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import load_faiss_index, search_faiss_index
 from config import Config

--- a/retrievers/external.py
+++ b/retrievers/external.py
@@ -4,11 +4,7 @@ Used to provide factual context for modern concepts and topics.
 """
 
 from typing import List, Tuple, Dict, Any
-import sys
 import os
-
-# Add parent directory to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import load_faiss_index, search_faiss_index
 from config import Config


### PR DESCRIPTION
## Summary
- drop unused imports from `main` and `loaders.ingest`
- remove `sys.path` hacks from retriever modules and ingestion module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_6868145e8db48329be59f3dbe08bb93e