### PR TITLE
Fix conversation history truncation

### DIFF
--- a/prompt_builder.py
+++ b/prompt_builder.py
@@ -180,8 +180,9 @@ Your responses should reflect your philosophical method: questioning, clarifying
         if not conversation_history:
             return "This is the beginning of our conversation."
 
-        # Limit history to recent turns
-        recent_history = conversation_history[-Config.MAX_HISTORY :]
+        # Limit history to the most recent conversation pairs
+        # (user and assistant messages)
+        recent_history = conversation_history[-Config.MAX_HISTORY * 2 :]
 
         conversation_parts = ["RECENT CONVERSATION:"]
         for turn in recent_history:


### PR DESCRIPTION
## Summary
- maintain user/assistant pairs when limiting conversation history

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686815b5396483298c1108239f0daaf9