### PR TITLE
Refactor retrievers with BaseRetriever

### DIFF
--- a/retrievers/__init__.py
+++ b/retrievers/__init__.py
@@ -3,6 +3,7 @@ Retrievers package for the Wittgenstein chatbot.
 Contains modules for retrieving content from different knowledge bases.
 """
 
+from .base import BaseRetriever
 from .authored import AuthoredTextRetriever
 from .descriptive import DescriptiveSourceRetriever
 from .external import ExternalKnowledgeRetriever
@@ -11,4 +12,6 @@ __all__ = [
     "AuthoredTextRetriever",
     "DescriptiveSourceRetriever",
     "ExternalKnowledgeRetriever",
+    "BaseRetriever",
 ]
+

--- a/retrievers/authored.py
+++ b/retrievers/authored.py
@@ -4,13 +4,12 @@ Used to determine response style and philosophical approach.
 """
 
 from typing import List, Tuple, Dict, Any
-import os
 
-from utils import load_faiss_index, search_faiss_index
 from config import Config
+from .base import BaseRetriever
 
 
-class AuthoredTextRetriever:
+class AuthoredTextRetriever(BaseRetriever):
     """
     Retriever for Wittgenstein's own writings.
     This retriever is used to find passages from Wittgenstein's works
@@ -19,44 +18,11 @@ class AuthoredTextRetriever:
 
     def __init__(self):
         """Initialize the authored text retriever."""
-        self.index = None
-        self.metadata = None
-        self.load_index()
-
-    def load_index(self):
-        """Load the FAISS index for authored texts."""
-        self.index, self.metadata = load_faiss_index(Config.AUTHORED_INDEX_PATH)
-        if self.index is None:
-            print("Warning: No authored text index found. Run data ingestion first.")
-
-    def retrieve(
-        self, query: str, top_k: int = None
-    ) -> List[Tuple[float, Dict[str, Any]]]:
-        """
-        Retrieve relevant passages from Wittgenstein's writings.
-
-        Args:
-            query: The search query
-            top_k: Number of results to return (defaults to config setting)
-
-        Returns:
-            List of (score, metadata) tuples
-        """
-        if top_k is None:
-            top_k = Config.TOP_K_AUTHORED
-
-        if self.index is None or self.metadata is None:
-            return []
-
-        results = search_faiss_index(
-            query=query,
-            index=self.index,
-            metadata=self.metadata,
-            top_k=top_k,
-            embedding_model=Config.EMBEDDING_MODEL,
+        super().__init__(
+            index_path=Config.AUTHORED_INDEX_PATH,
+            default_top_k=Config.TOP_K_AUTHORED,
         )
 
-        return results
 
     def get_style_examples(self, query: str) -> str:
         """
@@ -80,6 +46,4 @@ class AuthoredTextRetriever:
 
         return style_text
 
-    def is_available(self) -> bool:
-        """Check if the authored text index is available."""
-        return self.index is not None and self.metadata is not None
+

--- a/retrievers/base.py
+++ b/retrievers/base.py
@@ -1,0 +1,41 @@
+"""Base retriever class for FAISS-backed indexes."""
+
+from typing import List, Tuple, Dict, Any
+
+from config import Config
+from utils import load_faiss_index, search_faiss_index
+
+
+class BaseRetriever:
+    """Generic retriever for FAISS indexes."""
+
+    def __init__(self, index_path: str, default_top_k: int):
+        self.index_path = index_path
+        self.default_top_k = default_top_k
+        self.index = None
+        self.metadata = None
+        self.load_index()
+
+    def load_index(self) -> None:
+        """Load the FAISS index and metadata."""
+        self.index, self.metadata = load_faiss_index(self.index_path)
+        if self.index is None:
+            print(f"Warning: No index found at {self.index_path}. Run data ingestion first.")
+
+    def retrieve(self, query: str, top_k: int | None = None) -> List[Tuple[float, Dict[str, Any]]]:
+        """Retrieve relevant entries for a query."""
+        if top_k is None:
+            top_k = self.default_top_k
+        if self.index is None or self.metadata is None:
+            return []
+        return search_faiss_index(
+            query=query,
+            index=self.index,
+            metadata=self.metadata,
+            top_k=top_k,
+            embedding_model=Config.EMBEDDING_MODEL,
+        )
+
+    def is_available(self) -> bool:
+        """Return True if the retriever index is available."""
+        return self.index is not None and self.metadata is not None

--- a/retrievers/descriptive.py
+++ b/retrievers/descriptive.py
@@ -4,13 +4,12 @@ Used to provide philosophical context and interpretation.
 """
 
 from typing import List, Tuple, Dict, Any
-import os
 
-from utils import load_faiss_index, search_faiss_index
 from config import Config
+from .base import BaseRetriever
 
 
-class DescriptiveSourceRetriever:
+class DescriptiveSourceRetriever(BaseRetriever):
     """
     Retriever for descriptive sources about Wittgenstein's thought.
     This retriever provides philosophical context and interpretation
@@ -19,46 +18,11 @@ class DescriptiveSourceRetriever:
 
     def __init__(self):
         """Initialize the descriptive source retriever."""
-        self.index = None
-        self.metadata = None
-        self.load_index()
-
-    def load_index(self):
-        """Load the FAISS index for descriptive sources."""
-        self.index, self.metadata = load_faiss_index(Config.DESCRIPTIVE_INDEX_PATH)
-        if self.index is None:
-            print(
-                "Warning: No descriptive source index found. Run data ingestion first."
-            )
-
-    def retrieve(
-        self, query: str, top_k: int = None
-    ) -> List[Tuple[float, Dict[str, Any]]]:
-        """
-        Retrieve relevant descriptive sources about Wittgenstein's thought.
-
-        Args:
-            query: The search query
-            top_k: Number of results to return (defaults to config setting)
-
-        Returns:
-            List of (score, metadata) tuples
-        """
-        if top_k is None:
-            top_k = Config.TOP_K_DESCRIPTIVE
-
-        if self.index is None or self.metadata is None:
-            return []
-
-        results = search_faiss_index(
-            query=query,
-            index=self.index,
-            metadata=self.metadata,
-            top_k=top_k,
-            embedding_model=Config.EMBEDDING_MODEL,
+        super().__init__(
+            index_path=Config.DESCRIPTIVE_INDEX_PATH,
+            default_top_k=Config.TOP_K_DESCRIPTIVE,
         )
 
-        return results
 
     def get_philosophical_context(self, query: str) -> str:
         """
@@ -83,6 +47,4 @@ class DescriptiveSourceRetriever:
 
         return context_text
 
-    def is_available(self) -> bool:
-        """Check if the descriptive source index is available."""
-        return self.index is not None and self.metadata is not None
+

--- a/retrievers/external.py
+++ b/retrievers/external.py
@@ -4,13 +4,12 @@ Used to provide factual context for modern concepts and topics.
 """
 
 from typing import List, Tuple, Dict, Any
-import os
 
-from utils import load_faiss_index, search_faiss_index
 from config import Config
+from .base import BaseRetriever
 
 
-class ExternalKnowledgeRetriever:
+class ExternalKnowledgeRetriever(BaseRetriever):
     """
     Retriever for external knowledge outside Wittgenstein's time.
     This retriever provides factual context for modern concepts,
@@ -19,46 +18,11 @@ class ExternalKnowledgeRetriever:
 
     def __init__(self):
         """Initialize the external knowledge retriever."""
-        self.index = None
-        self.metadata = None
-        self.load_index()
-
-    def load_index(self):
-        """Load the FAISS index for external knowledge."""
-        self.index, self.metadata = load_faiss_index(Config.EXTERNAL_INDEX_PATH)
-        if self.index is None:
-            print(
-                "Warning: No external knowledge index found. Run data ingestion first."
-            )
-
-    def retrieve(
-        self, query: str, top_k: int = None
-    ) -> List[Tuple[float, Dict[str, Any]]]:
-        """
-        Retrieve relevant external knowledge for the given query.
-
-        Args:
-            query: The search query
-            top_k: Number of results to return (defaults to config setting)
-
-        Returns:
-            List of (score, metadata) tuples
-        """
-        if top_k is None:
-            top_k = Config.TOP_K_EXTERNAL
-
-        if self.index is None or self.metadata is None:
-            return []
-
-        results = search_faiss_index(
-            query=query,
-            index=self.index,
-            metadata=self.metadata,
-            top_k=top_k,
-            embedding_model=Config.EMBEDDING_MODEL,
+        super().__init__(
+            index_path=Config.EXTERNAL_INDEX_PATH,
+            default_top_k=Config.TOP_K_EXTERNAL,
         )
 
-        return results
 
     def get_factual_context(self, query: str) -> str:
         """
@@ -83,6 +47,4 @@ class ExternalKnowledgeRetriever:
 
         return context_text
 
-    def is_available(self) -> bool:
-        """Check if the external knowledge index is available."""
-        return self.index is not None and self.metadata is not None
+


### PR DESCRIPTION
## Summary
- add `BaseRetriever` with common retrieval logic
- subclass each specialized retriever from the base
- expose `BaseRetriever` in the retrievers package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686816bf8bbc8329896b5a513ce98410