### PR TITLE
Optimize embedding usage

### DIFF
--- a/retrievers/base.py
+++ b/retrievers/base.py
@@ -4,6 +4,7 @@ from typing import List, Tuple, Dict, Any
 
 from config import Config
 from utils import load_faiss_index, search_faiss_index
+from langchain_openai import OpenAIEmbeddings
 
 
 class BaseRetriever:
@@ -14,6 +15,8 @@ class BaseRetriever:
         self.default_top_k = default_top_k
         self.index = None
         self.metadata = None
+        # Initialize embeddings once per retriever
+        self.embeddings = OpenAIEmbeddings(model=Config.EMBEDDING_MODEL)
         self.load_index()
 
     def load_index(self) -> None:
@@ -34,6 +37,7 @@ class BaseRetriever:
             metadata=self.metadata,
             top_k=top_k,
             embedding_model=Config.EMBEDDING_MODEL,
+            embeddings=self.embeddings,
         )
 
     def is_available(self) -> bool:

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ Utility functions for the Wittgenstein chatbot.
 
 import os
 import json
-from typing import List, Dict
+from typing import List, Dict, Optional
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_openai import OpenAIEmbeddings
 from langchain.schema import Document
@@ -141,6 +141,7 @@ def search_faiss_index(
     metadata: List[Dict],
     top_k: int,
     embedding_model: str = "text-embedding-ada-002",
+    embeddings: Optional[OpenAIEmbeddings] = None,
 ):
     """
     Search a FAISS index for similar documents.
@@ -150,7 +151,8 @@ def search_faiss_index(
         index: FAISS index
         metadata: Document metadata
         top_k: Number of results to return
-        embedding_model: OpenAI embedding model to use
+        embedding_model: OpenAI embedding model to use when `embeddings` is None
+        embeddings: Optional pre-initialized OpenAIEmbeddings instance
 
     Returns:
         List of (score, document_content) tuples
@@ -159,7 +161,8 @@ def search_faiss_index(
         return []
 
     # Get query embedding
-    embeddings = OpenAIEmbeddings(model=embedding_model)
+    if embeddings is None:
+        embeddings = OpenAIEmbeddings(model=embedding_model)
     query_embedding = embeddings.embed_query(query)
     query_vector = np.array([query_embedding]).astype("float32")
 


### PR DESCRIPTION
## Summary
- allow passing an embedding instance to `search_faiss_index`
- store one `OpenAIEmbeddings` object per retriever
- pass that embedding object to avoid recreating embeddings on every search

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686818c5ed288329b6dfd65135d454cc