### PR TITLE
Remove unused format helper

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -178,39 +178,6 @@ def search_faiss_index(
     return results
 
 
-def format_retrieved_content(
-    authored_results: List, descriptive_results: List, external_results: List
-) -> str:
-    """
-    Format retrieved content for inclusion in the prompt.
-
-    Args:
-        authored_results: Results from authored text search
-        descriptive_results: Results from descriptive sources search
-        external_results: Results from external knowledge search
-
-    Returns:
-        Formatted string for prompt inclusion
-    """
-    formatted = ""
-
-    if authored_results:
-        formatted += "=== WITTGENSTEIN'S WRITINGS (for style reference) ===\n"
-        for i, (score, metadata) in enumerate(authored_results, 1):
-            formatted += f"{i}. {metadata.get('content', 'No content')}\n\n"
-
-    if descriptive_results:
-        formatted += "=== PHILOSOPHICAL CONTEXT ===\n"
-        for i, (score, metadata) in enumerate(descriptive_results, 1):
-            formatted += f"{i}. {metadata.get('content', 'No content')}\n\n"
-
-    if external_results:
-        formatted += "=== EXTERNAL KNOWLEDGE (for factual context) ===\n"
-        for i, (score, metadata) in enumerate(external_results, 1):
-            formatted += f"{i}. {metadata.get('content', 'No content')}\n\n"
-
-    return formatted
-
 
 def truncate_text(text: str, max_tokens: int = 1000) -> str:
     """


### PR DESCRIPTION
## Summary
- drop `format_retrieved_content` from utils since it was unused

## Testing
- `python -m py_compile utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68681dc2c6788329ba6fe5c3073e98c3